### PR TITLE
chore: group dependabot updates per package manager

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,13 +5,25 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
+    groups:
+      docker:
+        patterns:
+          - "*"
 
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "monthly"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
 
   - package-ecosystem: "maven"
     directory: "/"
     schedule:
       interval: "monthly"
+    groups:
+      maven:
+        patterns:
+          - "*"


### PR DESCRIPTION
## Summary
Groups Dependabot updates by package manager (docker, github-actions, maven) so each ecosystem's updates land in a single PR instead of one per dependency.

## Why
Reduces PR noise from Dependabot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)